### PR TITLE
refs bugfix/missing-env-variables - add missing BOP_ENV variable to .…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,11 +4,16 @@ MQTT_PORT=
 AMQP_HOST=
 AMQP_PORT=
 
-COMM_TYPE= # mqtt OR amqp
-COMM_NAME= # queue or topic name
+# mqtt OR amqp OR Mock for local testing
+COMM_TYPE=
+# queue or topic name
+COMM_NAME=
 
 LOG_LEVEL=
 
-# Hardware configuration - enable any you have
-MIC_INSTALLED=False
-CAM_INSTALLED=False
+# Hardware configuration - enable any you have (True / False)
+MIC_INSTALLED=
+CAM_INSTALLED=
+
+# bops env - dev or prod
+BOP_ENV=


### PR DESCRIPTION
…env.example